### PR TITLE
Slow down the fade to black time

### DIFF
--- a/src/fade_black.rs
+++ b/src/fade_black.rs
@@ -15,7 +15,7 @@ use wayland_protocols_wlr::layer_shell::v1::client::{zwlr_layer_shell_v1, zwlr_l
 
 use crate::{State, StateInner};
 
-const FADE_TIME: Duration = Duration::from_millis(2000);
+const FADE_TIME: Duration = Duration::from_secs(5);
 
 #[derive(Debug)]
 pub struct FadeBlackSurface {


### PR DESCRIPTION
It's waaaaay too fast right now. You need to be able to react fast enough to stop it going to sleep while you're not actively using your computer.