### PR TITLE
Use 'loginctl lock-session' as fallback command for lock_screen

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -171,12 +171,11 @@ impl State {
     }
 
     fn lock_screen(&self) {
-        if let Some(command) = self
+        let command = self
             .system_actions
             .get(&shortcuts::action::System::LockScreen)
-        {
-            crate::run_command(command.to_string());
-        }
+            .map_or("loginctl lock-session", |s| s.as_str());
+        crate::run_command(command.to_string());
     }
 
     fn update_suspend_idle(&mut self, is_idle: bool) {


### PR DESCRIPTION
On alpha 6, screen wont auto lock on idle, presumably because of outdated cosmic_settings_config dep, which does not have LogOut action in Enum:
```[2025-02-24T20:47:38Z ERROR cosmic_settings_config::shortcuts] failed to read system shortcuts config 'system_actions': RonSpanned(SpannedError { code: NoSuchEnumVariant { expected: ["AppLibrary", "BrightnessDown", "BrightnessUp", "HomeFolder", "KeyboardBrightnessDown", "KeyboardBrightnessUp", "Launcher", "LockScreen", "Mute", "MuteMic", "PlayPause", "PlayNext", "PlayPrev", "Screenshot", "Terminal", "VolumeLower", "VolumeRaise", "WebBrowser", "WindowSwitcher", "WindowSwitcherPrevious", "WorkspaceOverview"], found: "LogOut", outer: Some("System") }, position: Position { line: 11, col: 11 } })```

I believe it is beneficial to have fallback action for such scenario.