### PR TITLE
Add shorter screen-off timeout when session is locked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,6 +475,7 @@ dependencies = [
  "futures-lite",
  "keyframe",
  "log",
+ "logind-zbus",
  "upower_dbus",
  "wayland-client",
  "wayland-protocols",
@@ -1165,6 +1166,16 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "logind-zbus"
+version = "5.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469c962578b549a82f3d0cc72d0f77d1123780fa7121e2b03d78b0780f6ccac6"
+dependencies = [
+ "serde",
+ "zbus",
+]
 
 [[package]]
 name = "malloc_buf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ env_logger = "0.11.8"
 upower_dbus = { git = "https://github.com/pop-os/dbus-settings-bindings" }
 zbus = "5.12"
 futures-lite = "2.6.1"
+logind-zbus = "5"
 
 [workspace]
 members = [

--- a/cosmic-idle-config/src/lib.rs
+++ b/cosmic-idle-config/src/lib.rs
@@ -5,6 +5,9 @@ use serde::{Deserialize, Serialize};
 pub struct CosmicIdleConfig {
     /// Screen off idle time, in ms
     pub screen_off_time: Option<u32>,
+    /// Screen off idle time when session is locked, in ms.
+    /// If None, falls back to screen_off_time.
+    pub screen_off_time_locked: Option<u32>,
     /// Suspend idle time when on battery, in ms
     pub suspend_on_battery_time: Option<u32>,
     /// Suspend idle time when on ac, in ms
@@ -15,6 +18,7 @@ impl Default for CosmicIdleConfig {
     fn default() -> Self {
         Self {
             screen_off_time: Some(15 * 60 * 1000),
+            screen_off_time_locked: Some(60 * 1000),
             suspend_on_battery_time: Some(15 * 60 * 1000),
             suspend_on_ac_time: Some(30 * 60 * 1000),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ const LOCK_SCREEN_DELAY: Duration = Duration::from_millis(500);
 enum Event {
     OnBattery(bool),
     ScreensaverInhibit(bool),
+    SessionLocked,
 }
 
 type EventSender = channel::Sender<Event>;
@@ -71,6 +72,28 @@ async fn receive_battery_task(sender: EventSender) -> zbus::Result<()> {
     Ok(())
 }
 
+// Listen for the logind Lock signal to detect external session locks
+// (e.g. keyboard shortcut, loginctl lock-session). Unlock is detected
+// internally via the Resumed idle notification event instead, since
+// COSMIC's screen locker doesn't emit the Unlock D-Bus signal.
+async fn receive_lock_signal_task(sender: EventSender) -> zbus::Result<()> {
+    let connection = zbus::Connection::system().await?;
+    let manager = logind_zbus::manager::ManagerProxy::new(&connection).await?;
+    let session_id = std::env::var("XDG_SESSION_ID").unwrap_or_else(|_| "auto".to_string());
+    let session_path = manager.get_session(&session_id).await?;
+
+    let session = logind_zbus::session::SessionProxy::builder(&connection)
+        .path(session_path)?
+        .build()
+        .await?;
+
+    let mut lock_stream = session.receive_lock().await?;
+    while lock_stream.next().await.is_some() {
+        let _ = sender.send(Event::SessionLocked);
+    }
+    Ok(())
+}
+
 #[derive(Debug)]
 struct Output {
     output: wl_output::WlOutput,
@@ -100,6 +123,7 @@ struct State {
     suspend_idle_notification: Option<IdleNotification>,
     on_battery: bool,
     screensaver_inhibit: bool,
+    session_locked: bool,
     system_actions: shortcuts::SystemActions,
     loop_handle: calloop::LoopHandle<'static, Self>,
 }
@@ -160,6 +184,13 @@ impl State {
             output.fade_surface = None;
         }
 
+        if !self.session_locked {
+            // Pre-empt the Lock signal so the shorter timeout is active during
+            // the brief window before logind delivers it.
+            self.session_locked = true;
+            self.recreate_notifications();
+        }
+
         let timer = timer::Timer::from_duration(LOCK_SCREEN_DELAY);
         self.loop_handle
             .insert_source(timer, |_, _, state| {
@@ -191,6 +222,8 @@ impl State {
     fn recreate_notifications(&mut self) {
         let screen_off_time = if self.screensaver_inhibit {
             None
+        } else if self.session_locked {
+            self.conf.screen_off_time_locked.or(self.conf.screen_off_time)
         } else {
             self.conf.screen_off_time
         };
@@ -199,7 +232,10 @@ impl State {
             self.screen_off_idle_notification =
                 screen_off_time.map(|time| IdleNotification::new(&self.inner, time));
             // Initially not idle; server sends `resumed` only after `idled`
-            self.update_screen_off_idle(false);
+            // When session is locked (screen already off), don't turn screen on.
+            if !self.session_locked {
+                self.update_screen_off_idle(false);
+            }
         }
 
         let suspend_time = if self.screensaver_inhibit {
@@ -225,6 +261,10 @@ impl State {
             }
             Event::ScreensaverInhibit(value) => {
                 self.screensaver_inhibit = value;
+                self.recreate_notifications();
+            }
+            Event::SessionLocked => {
+                self.session_locked = true;
                 self.recreate_notifications();
             }
         }
@@ -302,6 +342,7 @@ fn main() {
         conf,
         on_battery: false,
         screensaver_inhibit: false,
+        session_locked: false,
         system_actions,
         loop_handle: event_loop.handle(),
     };
@@ -335,6 +376,14 @@ fn main() {
         .schedule(async move {
             if let Err(err) = receive_battery_task(sender_clone).await {
                 log::error!("Getting battery status from upower: {}", err);
+            }
+        })
+        .unwrap();
+    let sender_clone = sender.clone();
+    scheduler
+        .schedule(async move {
+            if let Err(err) = receive_lock_signal_task(sender_clone).await {
+                log::error!("failed to listen for session lock signal: {}", err);
             }
         })
         .unwrap();
@@ -409,6 +458,12 @@ impl Dispatch<ext_idle_notification_v1::ExtIdleNotificationV1, ()> for State {
             == Some(notification)
         {
             state.update_screen_off_idle(is_idle);
+            // When user becomes active again, clear the locked state so
+            // the normal (longer) screen-off timeout is used.
+            if !is_idle && state.session_locked {
+                state.session_locked = false;
+                state.recreate_notifications();
+            }
         } else if state
             .suspend_idle_notification
             .as_ref()


### PR DESCRIPTION
Implement missing timeout requested in https://github.com/pop-os/cosmic-epoch/issues/2140

Add screen_off_time_locked config field (default 60 s) used instead of screen_off_time when the session is locked. Falls back to screen_off_time if unset.

Lock detection uses the logind Lock D-Bus signal via logind-zbus. Unlock detection is activity-based (Resumed idle event) rather than signal-based cosmic-greeter does not emit the logind Unlock signal. (Verified on Fedora 44 / cosmic-greeter 1.0.11 with gdbus monitor; see also https://github.com/pop-os/cosmic-epoch/issues/1764)

A LLM was used to analyze the code paths and draft the patch. End-to-end tested on Fedora 44.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

