### PR TITLE
Recreate idle notifications when AC/battery state changes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -222,6 +222,7 @@ impl State {
         match event {
             Event::OnBattery(value) => {
                 self.on_battery = value;
+                self.recreate_notifications();
             }
             Event::ScreensaverInhibit(value) => {
                 self.screensaver_inhibit = value;


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

## Problem

The suspend idle notification is only created in `recreate_notifications()`, which is called on startup, on config change, and when the screensaver inhibit state changes. `handle_event()` updates `self.on_battery` but does not call it:

```rust
Event::OnBattery(value) => {
    self.on_battery = value;          // no recreate_notifications()
}
Event::ScreensaverInhibit(value) => {
    self.screensaver_inhibit = value;
    self.recreate_notifications();
}
```

Since `suspend_time` is selected from `on_battery`:

```rust
let suspend_time = if self.screensaver_inhibit { None }
    else if self.on_battery { self.conf.suspend_on_battery_time }
    else { self.conf.suspend_on_ac_time };
```

the timeout picked at startup is kept for the whole session.

`on_battery` starts as `false`, so with **"Automatic suspend when plugged in: Never"** (`suspend_on_ac_time = None`) no suspend notification is created at startup. Unplugging the AC adapter later sets `on_battery = true` but never recreates the notification, so **the machine stops suspending on idle entirely** until cosmic-idle is restarted or a config key happens to be written.

`screen_off_time` does not depend on `on_battery`, so the screen still blanks and locks normally. That makes this look like anything but a timer problem — in my case a laptop sat awake for 7h15m with the lid open and drained from 60% to 17%, while the screen had dutifully turned off and locked.

The inverse case is affected too: a laptop started on battery keeps using `suspend_on_battery_time` after being plugged in.

This is the behaviour @l-const suspected in https://github.com/pop-os/cosmic-idle/issues/9#issuecomment-2469862325 ("if the var is set only on startup, maybe an enhancement is needed?"). It is not just a missed enhancement — with `suspend_on_ac_time = None` it disables idle suspend outright.

## Fix

Call `recreate_notifications()` when the AC/battery state changes, exactly as the screensaver inhibit path already does.

## Testing

ThinkPad X1 Nano running NixOS, cosmic-idle 1.4.0, with `suspend_on_ac_time = None` and `suspend_on_battery_time` set to 1 minute. Patched and unpatched binaries were run side by side, both started while on AC:

| | unpatched | patched |
| --- | --- | --- |
| after unplugging AC | never suspends | suspends after 1 min, repeatedly |
| after plugging AC back in | (n/a) | stops suspending, as configured |

```
18:37:35 systemd-logind: suspend requested from client ('systemctl')
18:37:35 kernel: PM: suspend entry (s2idle)
18:38:57 systemd-logind: suspend requested from client ('systemctl')
18:38:58 kernel: PM: suspend entry (s2idle)
```