### PR TITLE
Re-arm the suspend timer when the power source changes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,7 @@ impl Drop for IdleNotification {
 async fn receive_battery_task(sender: EventSender) -> zbus::Result<()> {
     let connection = zbus::Connection::system().await?;
     let upower = UPowerProxy::new(&connection).await?;
+    let _ = sender.send(Event::OnBattery(upower.on_battery().await?));
     let mut stream = upower.receive_on_battery_changed().await;
     while let Some(event) = stream.next().await {
         let _ = sender.send(Event::OnBattery(event.get().await?));
@@ -222,6 +223,7 @@ impl State {
         match event {
             Event::OnBattery(value) => {
                 self.on_battery = value;
+                self.recreate_notifications();
             }
             Event::ScreensaverInhibit(value) => {
                 self.screensaver_inhibit = value;


### PR DESCRIPTION
### Problem
With **Automatic suspend when plugged in: Never**, the system still auto-suspends on AC — using the on-battery timeout — after a battery→AC transition.

### Cause
`handle_event` updates the cached `on_battery` flag on a UPower change but never re-arms the suspend notification, unlike the `ScreensaverInhibit` arm which calls `recreate_notifications()`. The timer armed for the previous power state therefore stays live and fires under the wrong power source. `receive_battery_task` also never reads the initial power state, defaulting `on_battery = false` until the first change event.

### Fix
- Seed the initial power state from UPower at startup.
- Call `recreate_notifications()` when `on_battery` changes, mirroring the existing `ScreensaverInhibit` handling.

Two lines, event-driven, no polling.

### Testing
- Before: reliable auto-suspend on AC every ~15 min despite "Never".
- After: no suspend on AC across extended idle and across unplug/replug cycles; battery auto-suspend and the screen-off timeout are unaffected.

Related to #9 — that report covers the same symptom and was closed as completed, but the underlying bug is still present as of `epoch-1.7.0`; this fixes the actual root cause.